### PR TITLE
pickling fixes

### DIFF
--- a/sisl/io/siesta/__init__.py
+++ b/sisl/io/siesta/__init__.py
@@ -67,5 +67,3 @@ from .siesta_nc import *
 from .siesta_grid import *
 from .transiesta_grid import *
 from .xv import *
-
-__all__ = [s for s in dir() if not s.startswith('_')]

--- a/sisl/io/siesta/binaries.py
+++ b/sisl/io/siesta/binaries.py
@@ -1259,13 +1259,20 @@ def _type(name, obj, dic=None):
             dic['__doc__'] = obj.__doc__.replace(obj.__name__, name)
         except:
             pass
-    return type(name, (obj, ), dic)
+    return set_module("sisl.io.siesta")(type(name, (obj, ), dic))
 
 # Faster than class ... \ pass
 tsgfSileSiesta = _type("tsgfSileSiesta", _gfSileSiesta)
 gridSileSiesta = _type("gridSileSiesta", _gridSileSiesta, {'grid_unit': 1.})
 
 if found_module:
+    def _create(suffix, name, base=_gridSileSiesta, **dic):
+        global __all__
+        __all__.append(name)
+        cls = _type(name, base, dic)
+        add_sile(suffix, cls)
+        return cls
+
     add_sile('TSHS', tshsSileSiesta)
     add_sile('onlyS', onlysSileSiesta)
     add_sile('TSDE', tsdeSileSiesta)
@@ -1273,23 +1280,28 @@ if found_module:
     add_sile('HSX', hsxSileSiesta)
     add_sile('TSGF', tsgfSileSiesta)
     add_sile('WFSX', wfsxSileSiesta)
+
     # These have unit-conversions
     BohrC2AngC = unit_convert('Bohr', 'Ang') ** 3
     Ry2eV = unit_convert('Ry', 'eV')
-    add_sile('RHO', _type("rhoSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
-    add_sile('LDOS', _type("ldosSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
-    add_sile('RHOINIT', _type("rhoinitSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
-    add_sile('RHOXC', _type("rhoxcSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
-    add_sile('DRHO', _type("drhoSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
-    add_sile('BADER', _type("baderSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
-    add_sile('IOCH', _type("iorhoSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
-    add_sile('TOCH', _type("totalrhoSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
+
+    rhoSileSiesta = _create('RHO', "rhoSileSiesta", grid_unit=1./BohrC2AngC)
+    ldosSileSiesta = _create('LDOS', "ldosSileSiesta", grid_unit=1./BohrC2AngC)
+    rhoinitSileSiesta = _create('RHOINIT', "rhoinitSileSiesta", grid_unit=1./BohrC2AngC)
+    rhoxcSileSiesta = _create('RHOXC', "rhoxcSileSiesta", grid_unit=1./BohrC2AngC)
+    drhoSileSiesta = _create('DRHO', "drhoSileSiesta", grid_unit=1./BohrC2AngC)
+    baderSileSiesta = _create('BADER', "baderSileSiesta", grid_unit=1./BohrC2AngC)
+    ionrhoSileSiesta = _create('IOCH', "ionrhoSileSiesta", grid_unit=1./BohrC2AngC)
+    totalrhoSileSiesta = _create('TOCH', "totalrhoSileSiesta", grid_unit=1./BohrC2AngC)
+
     # The following two files *require* that
     #  STM.DensityUnits   Ele/bohr**3
     #  which I can't check!
     # They are however the default
-    add_sile('STS', _type("stsSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
-    add_sile('STM.LDOS', _type("stmldosSileSiesta", _gridSileSiesta, {'grid_unit': 1./BohrC2AngC}))
-    add_sile('VH', _type("hartreeSileSiesta", _gridSileSiesta, {'grid_unit': Ry2eV}))
-    add_sile('VNA', _type("neutralatomhartreeSileSiesta", _gridSileSiesta, {'grid_unit': Ry2eV}))
-    add_sile('VT', _type("totalhartreeSileSiesta", _gridSileSiesta, {'grid_unit': Ry2eV}))
+    stsSileSiesta = _create('STS', "stsSileSiesta", grid_unit=1./BohrC2AngC)
+    stmldosSileSiesta = _create('STM.LDOS', "stmldosSileSiesta", grid_unit=1./BohrC2AngC)
+
+    # potential grids
+    hartreeSileSiesta = _create('VH', "hartreeSileSiesta", grid_unit=Ry2eV)
+    neutralatomhartreeSileSiesta = _create('VNA', "neutralatomhartreeSileSiesta", grid_unit=Ry2eV)
+    totalhartreeSileSiesta = _create('VT', "totalhartreeSileSiesta", grid_unit=Ry2eV)

--- a/sisl/io/sile.py
+++ b/sisl/io/sile.py
@@ -427,10 +427,10 @@ class BaseSile:
 
     def __getstate__(self):
         """This method and __setstate__ avoid errors when pickling siles"""
-        return self.__dict__ 
+        return self.__dict__
 
     def __setstate__(self, state):
-        """This method and __getstate__ avoid errors when pickling siles""" 
+        """This method and __getstate__ avoid errors when pickling siles"""
         self.__dict__ = state
 
     @classmethod

--- a/sisl/io/tbtrans/pht.py
+++ b/sisl/io/tbtrans/pht.py
@@ -6,7 +6,7 @@ from .tbt import tbtncSileTBtrans, tbtavncSileTBtrans, Ry2K, Ry2eV
 __all__ = ['phtncSilePHtrans', 'phtavncSilePHtrans']
 
 
-@set_module("sisl.io.phtrans")
+@set_module("sisl.io.tbtrans")
 class phtncSilePHtrans(tbtncSileTBtrans):
     """ PHtrans file object """
     _trans_type = 'PHT'
@@ -21,7 +21,7 @@ class phtncSilePHtrans(tbtncSileTBtrans):
         return self._value('kT', self._elec(elec))[0] * Ry2eV
 
 
-@set_module("sisl.io.phtrans")
+@set_module("sisl.io.tbtrans")
 class phtavncSilePHtrans(tbtavncSileTBtrans):
     """ PHtrans file object """
     _trans_type = 'PHT'

--- a/sisl/io/tbtrans/phtproj.py
+++ b/sisl/io/tbtrans/phtproj.py
@@ -7,7 +7,7 @@ from .tbtproj import tbtprojncSileTBtrans
 __all__ = ['phtprojncSilePHtrans']
 
 
-@set_module("sisl.io.phtrans")
+@set_module("sisl.io.tbtrans")
 class phtprojncSilePHtrans(tbtprojncSileTBtrans):
     """ PHtrans projection file object """
     _trans_type = 'PHT.Proj'

--- a/sisl/io/tbtrans/se.py
+++ b/sisl/io/tbtrans/se.py
@@ -292,7 +292,7 @@ add_sile('TBT_UP.SE.nc', tbtsencSileTBtrans)
 add_sile('TBT_DN.SE.nc', tbtsencSileTBtrans)
 
 
-@set_module("sisl.io.phtrans")
+@set_module("sisl.io.tbtrans")
 class phtsencSilePHtrans(tbtsencSileTBtrans):
     """ PHtrans file object """
     _trans_type = 'PHT'

--- a/sisl/io/tests/test_sile.py
+++ b/sisl/io/tests/test_sile.py
@@ -26,5 +26,3 @@ def test_sile_pickling(sisl_tmp, sile_cls, pickle_mod):
 
     with open(tmp_file, "rb") as fh:
         loaded_sile = pickle_mod.load(fh)
-
-    


### PR DESCRIPTION
Please see the changes I did in the tests folder. Basically you shouldn't use the request for *anything* (very rarely)

In sisl we have a `sisl/conftest.py` file which governs the pytest scheme all-around. You'll notice here a few fixtures which gets exposed everywhere.

If you want temporary files, please use `sisl_tmp` which does some more magic :+1: 

If you have questions related to the change, please let me know. Your test showed some module inconsistencies which is also fixed in this PR :)